### PR TITLE
Chrome menu fix: the reimagining

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,12 @@
 				<div class='label-spacer'>
 					<span class='deadzone font-ailerons'>
 						About
-						<div class='submenu' hidden>
+						<div class='submenu'>
 							<div class='submenu-option'>
 								<span class='deadzone font-ailerons'>
 									Me
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									I love finding solutions to new and different problems. I get anxious if
 									I'm not learning and improving.
 								</div>
@@ -25,7 +25,7 @@
 								<span class='deadzone font-ailerons'>
 									Programming
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									I'm a self-taught programmer--I got
 									into web development and programming
 									to pay for my degree, and found a
@@ -36,7 +36,7 @@
 								<span class='deadzone font-ailerons'>
 									Civil Engineering
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									My (currently ongoing) subject of 
 									study. When I graduate, my goal is
 									to find some way to incorporate Civil
@@ -53,12 +53,12 @@
 				<div class='label-spacer'>
 					<span class='deadzone font-ailerons'>
 						Projects
-						<div class='submenu' hidden>
+						<div class='submenu'>
 							<div class='submenu-option'>
 								<span class='deadzone font-ailerons'>
 									AlgoDa
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									Library of algorithms and datastructures
 									written in c++. Practice for now, for use
 									later.
@@ -68,7 +68,7 @@
 								<span class='deadzone font-ailerons'>
 									LudumDare 34 Entry
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									First attempt at creating a game starting
 									with low-level windows API calls and very
 									simple software rendering.
@@ -84,12 +84,12 @@
 				<div class='label-spacer'>
 					<span class='deadzone font-ailerons'>
 						Contact
-						<div class='submenu' hidden>
+						<div class='submenu'>
 							<div class='submenu-option'>
 								<span class='deadzone font-ailerons'>
 									Phone
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									(847) 207-8622
 								</div>
 							</div>
@@ -97,7 +97,7 @@
 								<span class='deadzone font-ailerons'>
 									Email
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									Ruy.Calderon@gmail.com
 								</div>
 							</div>
@@ -109,12 +109,12 @@
 				<div class='label-spacer'>
 					<span class='deadzone font-ailerons'>
 						Portfolio
-						<div class='submenu' hidden>
+						<div class='submenu'>
 							<div class='submenu-option'>
 								<span class='deadzone font-ailerons'>
 									
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									Really not much to put here...
 								</div>
 							</div>
@@ -126,12 +126,12 @@
 				<div class='label-spacer'>
 					<span class='deadzone font-ailerons'>
 						Resume
-						<div class='submenu' hidden>
+						<div class='submenu'>
 							<div class='submenu-option deadzone'>
 								<span class='deadzone font-ailerons'>
 									For Employers
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									Blah
 								</div>
 							</div>
@@ -139,7 +139,7 @@
 								<span class='deadzone font-ailerons'>
 									For Clients
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									Blah
 								</div>
 							</div>
@@ -147,7 +147,7 @@
 								<span class='deadzone font-ailerons'>
 									For Everyone
 								</span>
-								<div class='submenu-popup' hidden>
+								<div class='submenu-popup'>
 									Blah
 								</div>
 							</div>
@@ -156,7 +156,7 @@
 				</div>
 			</span>
 		</div>
-		<div class='main-content' hidden>
+		<div class='main-content'>
 			<!-- <iframe src='projects/index.html'>
 			</iframe> -->
 		</div>

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ $(document).ready(function(event) {
 			var endFontSize = 48;
 
 			if(!$(event.target).hasClass('deadzone') && $(event.target).parents('.deadzone').length == 0){
-				$(event.target).find('.submenu').attr('hidden','true');
+				$(event.target).find('.submenu').css('display','none');
 
 				var deadzone = $(event.target).children('.deadzone');
 				var deadZoneWidth = domStrToFloat($(deadzone).css('width'));
@@ -56,19 +56,16 @@ $(document).ready(function(event) {
 			else{
 				$(this).siblings().each(function(){
 					setDefaultSize(this, startFontSize);
-					$(event.target).children('.submenu').children('submenu-popup').each(function(){
-						$(this).attr('hidden','true');
-					});
+					$(this).find('.submenu').css('display','none');
+					//have to add below line to work around bug in chrome in which the width of
+					//the span is miscalculated after hiding the submenu
+					$($(this).find('.deadzone')[0]).css('display','none').css('display','inline-block');
 				});
-				$(event.target).children('.submenu').removeAttr('hidden');
-			}
-		});
+				$(event.target).find('.submenu').css('display','block');
 
-		// $(this).find('.submenu').children('.submenu-option').each(function(){
-		// 	$(this).find('.deadzone').on('click',funcion(){
-		// 		$(this).siblings().find('.submenu-popup').attr('hidden','false');
-		// 	});
-		// });
+			}
+			
+		});
 	});
 
 });

--- a/styles.css
+++ b/styles.css
@@ -18,14 +18,19 @@
 
 .navbar-option{
 	position: absolute; 
-	text-align:center; 
+	text-align: center; 
 	width:19%;
 	height:95%;
 	color:#322A22;
 	font-size:32px;
 }
+
 .submenu{
 	margin-top:-10px;
+	display:none;
+}
+.submenu-popup{
+	display:none;
 }
 
 .submenu-option{
@@ -37,6 +42,10 @@
 
 .submenu-option:hover{
 	font-size:28px;
+}
+
+.main-content{
+	display:none;
 }
 
 


### PR DESCRIPTION
I think it is a bug in chrome--but what was happening is that when I was setting the css of a child element that accompanied raw text in a parent div (so raw text then child element in the element) to display:none, an additional permanent 20 px width was added to the width of the element (which is supposed to be as close an approximation to the size of the enclosing text as possible).

I'm going to do a bit more research to make sure that it isn't something I'm fucking up and Mozilla isn't just doing the due-diligence for me or whatever, but if not I'm going to submit a ticket to chrome. Probably need to reword it though...
